### PR TITLE
Fix pdftk version parsing problem in 3.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    active_pdftk (0.1.0)
+    active_pdftk (0.1.1)
       builder (>= 2.1.2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    builder (3.0.0)
+    builder (3.2.3)
     diff-lcs (1.1.2)
     fuubar (0.0.5)
       rspec (~> 2.0)
@@ -35,3 +35,6 @@ DEPENDENCIES
   rake (>= 0.8.7)
   rspec (~> 2.6.0)
   yard
+
+BUNDLED WITH
+   1.17.3

--- a/lib/active_pdftk/call.rb
+++ b/lib/active_pdftk/call.rb
@@ -292,7 +292,7 @@ module ActivePdftk
     # @return [String]
     #
     def pdftk_version
-      %x{#{@default_statements[:path]} --version 2>&1}.scan(/pdftk (\S*) a Handy Tool/).join
+      %x{#{@default_statements[:path]} --version 2>&1}.scan(/pdftk (port to java )?(\S*) a Handy Tool/).flatten.last
     end
 
     # Return the path of the pdftk library if it can be located.

--- a/lib/active_pdftk/version.rb
+++ b/lib/active_pdftk/version.rb
@@ -1,5 +1,5 @@
 # Gem Version
 module ActivePdftk
   # current version number for the .gemspec
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
When doing a `pdftk --version` command, version 2.02 gives `pdftk 2.02 a Handy Tool` but version 3.0.2 gives `pdftk port to java 3.0.2 a Handy Tool`. Hence the old regex wouldn't work on the newer version.

Updating the regex so that it'll work on both versions.